### PR TITLE
ci: remove codecov

### DIFF
--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -42,8 +42,3 @@ jobs:
         env:
           SKIP_DOWNLOAD_CORE: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-      - name: Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 ![Windows x64](https://img.shields.io/badge/Support-Windows%20x64-blue?logo=Windows&style=flat-square)
 ![Windows arm64](https://img.shields.io/badge/Support-Windows%20arm64-blue?logo=Windows&style=flat-square)
 ![Linux x64](https://img.shields.io/badge/Support-Linux%20x64-blue?logo=Linux&style=flat-square)
-[![codecov](https://codecov.io/gh/Tohrusky/Final2x/branch/main/graph/badge.svg?token=LL6K2P1RS8)](https://codecov.io/gh/Tohrusky/Final2x)
 [![CI-test](https://github.com/Tohrusky/Final2x/actions/workflows/CI-test.yml/badge.svg)](https://github.com/Tohrusky/Final2x/actions/workflows/CI-test.yml)
 [![CI-build](https://github.com/Tohrusky/Final2x/actions/workflows/CI-build.yml/badge.svg)](https://github.com/Tohrusky/Final2x/actions/workflows/CI-build.yml)
 [![Release](https://github.com/Tohrusky/Final2x/actions/workflows/Release.yml/badge.svg)](https://github.com/Tohrusky/Final2x/actions/workflows/Release.yml)


### PR DESCRIPTION
## Summary by Sourcery

Remove Codecov integration from the CI workflow and update the README to reflect this change by removing the Codecov badge.

CI:
- Remove Codecov integration from the CI workflow.

Documentation:
- Remove Codecov badge from the README file.